### PR TITLE
Add caddy validate tunnel controller

### DIFF
--- a/app/Factory.php
+++ b/app/Factory.php
@@ -172,6 +172,15 @@ class Factory
         $this->router->get('/api/health', HealthController::class, $adminCondition);
     }
 
+    protected function addValidateTunnel()
+    {
+        $localCondition = 'request.headers.get("Host") matches "/^'.$this->host.':'.$this->port.'$/i"';
+
+        $this->router->get('/validate-tunnel', ValidateTunnelController::class, $localCondition);
+
+        return $this;
+    }
+
     protected function bindConfiguration()
     {
         app()->singleton(Configuration::class, function ($app) {

--- a/app/Http/Controllers/ValidateTunnelController.php
+++ b/app/Http/Controllers/ValidateTunnelController.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Expose\Server\Http\Controllers;
+
+use Expose\Server\Contracts\ConnectionManager;
+use Expose\Common\Http\Controllers\Controller;
+use Expose\Server\Configuration;
+use Expose\Server\Connections\ControlConnection;
+use Illuminate\Http\Request;
+use Ratchet\ConnectionInterface;
+
+class ValidateTunnelController extends Controller
+{
+    private ConnectionManager $connectionManager;
+    private Configuration $configuration;
+
+    public function __construct(
+        Configuration $configuration,
+        ConnectionManager $connectionManager,
+    ) {
+        $this->connectionManager = $connectionManager;
+        $this->configuration = $configuration;
+    }
+
+    public function handle(Request $request, ConnectionInterface $httpConnection)
+    {
+        $key = $request->get('key');
+
+        // Only allow requests with the correct key
+        if ($key !== $this->getAuthorizedKey()) {
+            $httpConnection->send(
+                respond_json(['exists' => false], 401),
+            );
+            $httpConnection->close();
+
+            return;
+        }
+
+        $domain = $request->get('domain');
+        if ($domain === null) {
+            $httpConnection->send(
+                respond_json(['exists' => false, 'error' => 'invalid_domain'], 404),
+            );
+            $httpConnection->close();
+
+            return;
+        }
+
+        // If the domain is the same as the hostname, then it requested the main domain
+        $hostname = $this->configuration->hostname();
+        if ($hostname === $domain) {
+            $this->isSuccessful($httpConnection);
+
+            return;
+        }
+
+        // Also allow the admin dashboard
+        $adminSubdomain = config('expose.admin.subdomain');
+        if ($domain === $adminSubdomain.'.'.$hostname) {
+            $this->isSuccessful($httpConnection);
+
+            return;
+        }
+
+        // Check if the domain is a tunnel
+        $sites = collect($this->connectionManager->getConnections())
+            ->filter(function ($site) use ($domain) {
+                $isControlConnection = get_class($site) === ControlConnection::class;
+                if (! $isControlConnection) {
+                    return false;
+                }
+
+                $fqdn = sprintf(
+                    '%s.%s',
+                    $site->subdomain,
+                    $site->serverHost,
+                );
+
+                return $fqdn === $domain;
+            })
+            ->map(function (ControlConnection $site) {
+                return sprintf(
+                    '%s.%s',
+                    $site->host,
+                    $site->subdomain,
+                );
+            });
+
+        if ($sites->count() > 0) {
+            $this->isSuccessful($httpConnection);
+
+            return;
+        }
+
+        $httpConnection->send(respond_json(['exists' => false, 'error' => 'no_tunnel_found'], 404));
+        $httpConnection->close();
+    }
+
+    private function isSuccessful(ConnectionInterface $connection): void
+    {
+        $connection->send(respond_json(['exists' => true]));
+        $connection->close();
+    }
+
+    private function getAuthorizedKey(): string
+    {
+        return config('expose.validate_tunnel.authorized_key');
+    }
+}

--- a/app/Http/Controllers/ValidateTunnelController.php
+++ b/app/Http/Controllers/ValidateTunnelController.php
@@ -55,7 +55,7 @@ class ValidateTunnelController extends Controller
         }
 
         // Also allow the admin dashboard
-        $adminSubdomain = config('expose.admin.subdomain');
+        $adminSubdomain = config('expose-server.admin.subdomain');
         if ($domain === $adminSubdomain.'.'.$hostname) {
             $this->isSuccessful($httpConnection);
 
@@ -104,6 +104,6 @@ class ValidateTunnelController extends Controller
 
     private function getAuthorizedKey(): string
     {
-        return config('expose.validate_tunnel.authorized_key');
+        return config('expose-server.validate_tunnel.authorized_key');
     }
 }

--- a/config/expose-server.php
+++ b/config/expose-server.php
@@ -191,4 +191,8 @@ return [
 
         'repository' => \Expose\Server\StatisticsRepository\DatabaseStatisticsRepository::class,
     ],
+
+    'validate_tunnel' => [
+        'authorized_key' => 'asHzMGp4y4fYmNzWAUmgsZZbcjSM5e',
+    ],
 ];


### PR DESCRIPTION
Add a tunnel validation route so that caddy can properly generate certificates, only if the tunnel exists:
https://caddyserver.com/docs/json/apps/tls/automation/on_demand/ask/