### PR TITLE
Add cooldown feature

### DIFF
--- a/app/Connections/ConnectionManager.php
+++ b/app/Connections/ConnectionManager.php
@@ -56,6 +56,7 @@ class ConnectionManager implements ConnectionManagerContract
             if ($cooldownPeriod > 0 && !empty($connection->authToken)) {
                 $cooldownEndsAt = time() + ($cooldownPeriod * 60);
                 app(\Expose\Server\Contracts\UserRepository::class)->setCooldownForToken($connection->authToken, $cooldownEndsAt);
+                $this->statisticsCollector->cooldownTriggered();
             }
         });
     }

--- a/app/Connections/ConnectionManager.php
+++ b/app/Connections/ConnectionManager.php
@@ -50,6 +50,13 @@ class ConnectionManager implements ConnectionManagerContract
 
         $this->loop->addTimer($maximumConnectionLength * 60, function () use ($connection) {
             $connection->closeWithoutReconnect();
+            
+            // Set cooldown for authenticated users
+            $cooldownPeriod = config('expose-server.connection_cooldown_period', 0);
+            if ($cooldownPeriod > 0 && !empty($connection->authToken)) {
+                $cooldownEndsAt = time() + ($cooldownPeriod * 60);
+                app(\Expose\Server\Contracts\UserRepository::class)->setCooldownForToken($connection->authToken, $cooldownEndsAt);
+            }
         });
     }
 

--- a/app/Contracts/StatisticsCollector.php
+++ b/app/Contracts/StatisticsCollector.php
@@ -10,6 +10,8 @@ interface StatisticsCollector
 
     public function incomingRequest();
 
+    public function cooldownTriggered();
+
     public function flush();
 
     public function save();

--- a/app/Contracts/UserRepository.php
+++ b/app/Contracts/UserRepository.php
@@ -23,4 +23,6 @@ interface UserRepository
     public function getUsersByTokens(array $authTokens): PromiseInterface;
 
     public function updateLastSharedAt($id): PromiseInterface;
+
+    public function setCooldownForToken(string $authToken, int $cooldownEndsAt): PromiseInterface;
 }

--- a/app/Http/Controllers/Admin/StoreSettingsController.php
+++ b/app/Http/Controllers/Admin/StoreSettingsController.php
@@ -29,9 +29,13 @@ class StoreSettingsController extends AdminController
 
         config()->set('expose-server.maximum_connection_length', $request->get('maximum_connection_length'));
 
+        config()->set('expose-server.connection_cooldown_period', $request->get('connection_cooldown_period'));
+
         config()->set('expose-server.messages.message_of_the_day', Arr::get($messages, 'message_of_the_day'));
 
         config()->set('expose-server.messages.custom_subdomain_unauthorized', Arr::get($messages, 'custom_subdomain_unauthorized'));
+
+        config()->set('expose-server.messages.connection_cooldown_active', Arr::get($messages, 'connection_cooldown_active'));
 
         $httpConnection->send(
             respond_json([

--- a/app/StatisticsRepository/DatabaseStatisticsRepository.php
+++ b/app/StatisticsRepository/DatabaseStatisticsRepository.php
@@ -29,7 +29,8 @@ class DatabaseStatisticsRepository implements StatisticsRepository
                 SUM(shared_ports) as shared_ports,
                 SUM(unique_shared_sites) as unique_shared_sites,
                 SUM(unique_shared_ports) as unique_shared_ports,
-                SUM(incoming_requests) as incoming_requests
+                SUM(incoming_requests) as incoming_requests,
+                SUM(cooldown_count) as cooldown_count
                 FROM statistics
                 WHERE
                 `timestamp` >= "'.$from.'" AND `timestamp` <= "'.$until.'"')

--- a/config/expose-server.php
+++ b/config/expose-server.php
@@ -56,6 +56,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Connection Cooldown Period
+    |--------------------------------------------------------------------------
+    |
+    | After a client is disconnected due to reaching the maximum connection
+    | length, they must wait this many minutes before reconnecting.
+    | Set to 0 to disable the cooldown period.
+    |
+    */
+    'connection_cooldown_period' => 0,
+
+    /*
+    |--------------------------------------------------------------------------
     | Maximum number of open connections
     |--------------------------------------------------------------------------
     |
@@ -182,6 +194,7 @@ return [
         'custom_domain_unauthorized' => 'You are not allowed to use this custom domain. If you think this should work, double-check the server setting and try again.',
 
         'maximum_connection_length_reached' => 'You have reached the maximum connection length for this server. Please upgrade to Expose Pro for unlimited connection length.',
+        'connection_cooldown_active' => 'You\'ve used your free session for now. Please wait :cooldown minutes before reconnecting, or upgrade to Expose Pro → https://expose.dev/pro',
     ],
 
     'statistics' => [

--- a/database/migrations/10_add_cooldown_ends_at_to_users_table.sql
+++ b/database/migrations/10_add_cooldown_ends_at_to_users_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN cooldown_ends_at INTEGER DEFAULT NULL;

--- a/database/migrations/11_add_cooldown_count_to_statistics_table.sql
+++ b/database/migrations/11_add_cooldown_count_to_statistics_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE statistics ADD COLUMN cooldown_count INTEGER DEFAULT 0;

--- a/tests/Feature/Server/CooldownTest.php
+++ b/tests/Feature/Server/CooldownTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Tests\Feature\Server;
+
+use Expose\Server\Factory;
+use React\Http\Browser;
+use Tests\Feature\TestCase;
+
+class CooldownTest extends TestCase
+{
+    /** @var Browser */
+    protected $browser;
+
+    /** @var Factory */
+    protected $serverFactory;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->browser = new Browser($this->loop);
+        $this->browser = $this->browser->withFollowRedirects(false);
+
+        $this->startServer();
+    }
+
+    public function tearDown(): void
+    {
+        $this->serverFactory->getSocket()->close();
+
+        $this->await(\React\Promise\Timer\resolve(0.2, $this->loop));
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_shows_cooldown_status_in_user_details()
+    {
+        // Create a user
+        $authToken = 'cooldown-test-token';
+        
+        $this->await($this->browser->post('http://127.0.0.1:8080/api/users', [
+            'Host' => 'expose.localhost',
+            'Authorization' => base64_encode('username:secret'),
+            'Content-Type' => 'application/json',
+        ], json_encode([
+            'name' => 'Cooldown Test User',
+            'auth_token' => $authToken,
+        ])));
+
+        // Set cooldown for the user (simulate they were disconnected)
+        $cooldownEndsAt = time() + (10 * 60); // 10 minutes from now
+        $userRepo = app(\Expose\Server\Contracts\UserRepository::class);
+        $this->await($userRepo->setCooldownForToken($authToken, $cooldownEndsAt));
+
+        // Get user details
+        $response = $this->await($this->browser->get('http://127.0.0.1:8080/api/users', [
+            'Host' => 'expose.localhost',
+            'Authorization' => base64_encode('username:secret'),
+        ]));
+
+        $body = json_decode($response->getBody()->getContents());
+        $users = $body->paginated->users;
+        
+        $cooldownUser = null;
+        foreach ($users as $user) {
+            if ($user->auth_token === $authToken) {
+                $cooldownUser = $user;
+                break;
+            }
+        }
+
+        $this->assertNotNull($cooldownUser);
+        $this->assertTrue($cooldownUser->is_in_cooldown);
+        $this->assertEquals(10, $cooldownUser->cooldown_minutes_remaining);
+    }
+
+    /** @test */
+    public function it_can_configure_cooldown_period_via_admin_api()
+    {
+        // Get current settings
+        $response = $this->await($this->browser->get('http://127.0.0.1:8080/api/settings', [
+            'Host' => 'expose.localhost',
+            'Authorization' => base64_encode('username:secret'),
+        ]));
+
+        $settings = json_decode($response->getBody()->getContents());
+        
+        // Update cooldown period
+        $response = $this->await($this->browser->post('http://127.0.0.1:8080/api/settings', [
+            'Host' => 'expose.localhost',
+            'Authorization' => base64_encode('username:secret'),
+            'Content-Type' => 'application/json',
+        ], json_encode([
+            'connection_cooldown_period' => 15,
+            'validate_auth_tokens' => $settings->configuration->validate_auth_tokens,
+            'maximum_connection_length' => $settings->configuration->maximum_connection_length,
+            'messages' => [
+                'invalid_auth_token' => $settings->configuration->messages->invalid_auth_token,
+                'subdomain_taken' => $settings->configuration->messages->subdomain_taken,
+                'message_of_the_day' => $settings->configuration->messages->message_of_the_day,
+                'custom_subdomain_unauthorized' => $settings->configuration->messages->custom_subdomain_unauthorized,
+                'connection_cooldown_active' => 'You must wait before reconnecting. Cooldown period expires in :minutes minutes.',
+            ],
+        ])));
+
+        $updatedSettings = json_decode($response->getBody()->getContents());
+        
+        $this->assertEquals(15, $updatedSettings->configuration->connection_cooldown_period);
+        $this->assertStringContainsString(':minutes', $updatedSettings->configuration->messages->connection_cooldown_active);
+    }
+
+    /** @test */
+    public function it_shows_no_cooldown_for_users_without_cooldown()
+    {
+        // Create a user without cooldown
+        $authToken = 'no-cooldown-user-token';
+        
+        $this->await($this->browser->post('http://127.0.0.1:8080/api/users', [
+            'Host' => 'expose.localhost',
+            'Authorization' => base64_encode('username:secret'),
+            'Content-Type' => 'application/json',
+        ], json_encode([
+            'name' => 'Regular User',
+            'auth_token' => $authToken,
+        ])));
+
+        // Get user details
+        $response = $this->await($this->browser->get('http://127.0.0.1:8080/api/users', [
+            'Host' => 'expose.localhost',
+            'Authorization' => base64_encode('username:secret'),
+        ]));
+
+        $body = json_decode($response->getBody()->getContents());
+        $users = $body->paginated->users;
+        
+        $regularUser = null;
+        foreach ($users as $user) {
+            if ($user->auth_token === $authToken) {
+                $regularUser = $user;
+                break;
+            }
+        }
+
+        $this->assertNotNull($regularUser);
+        $this->assertFalse($regularUser->is_in_cooldown);
+        $this->assertEquals(0, $regularUser->cooldown_minutes_remaining);
+    }
+
+    protected function startServer()
+    {
+        $this->app['config']['expose-server.subdomain'] = 'expose';
+        $this->app['config']['expose-server.database'] = ':memory:';
+
+        $this->app['config']['expose-server.users'] = [
+            'username' => 'secret',
+        ];
+
+        $this->serverFactory = new Factory();
+
+        $this->serverFactory->setLoop($this->loop)
+            ->createServer();
+    }
+}


### PR DESCRIPTION
This PR adds the ability to specify a "cooldown" that triggers as soon as a user gets the connection closed due to their maximum connection length limit.
The amount of minutes a user has to wait before being able to reconnect can be configured or disabled entirely.