### PR TITLE
Skip free-server time limits for pro users

### DIFF
--- a/app/Connections/ConnectionManager.php
+++ b/app/Connections/ConnectionManager.php
@@ -40,9 +40,9 @@ class ConnectionManager implements ConnectionManagerContract
         $this->logger = $logger;
     }
 
-    public function limitConnectionLength(ControlConnection $connection, int $maximumConnectionLength)
+    public function limitConnectionLength(ControlConnection $connection, int $maximumConnectionLength, ?array $user = null)
     {
-        if ($maximumConnectionLength === 0) {
+        if ($maximumConnectionLength === 0 || $this->userIsExemptFromConnectionLimit($user)) {
             return;
         }
 
@@ -59,6 +59,11 @@ class ConnectionManager implements ConnectionManagerContract
                 $this->statisticsCollector->cooldownTriggered();
             }
         });
+    }
+
+    protected function userIsExemptFromConnectionLimit(?array $user): bool
+    {
+        return ! is_null($user) && (int) ($user['can_specify_subdomains'] ?? 0) === 1;
     }
 
     public function storeConnection(string $host, ?string $subdomain, ?string $serverHost, ConnectionInterface $connection): ControlConnection

--- a/app/Contracts/ConnectionManager.php
+++ b/app/Contracts/ConnectionManager.php
@@ -12,7 +12,7 @@ interface ConnectionManager
 
     public function storeTcpConnection(int $port, ConnectionInterface $connection): ControlConnection;
 
-    public function limitConnectionLength(ControlConnection $connection, int $maximumConnectionLength);
+    public function limitConnectionLength(ControlConnection $connection, int $maximumConnectionLength, ?array $user = null);
 
     public function storeHttpConnection(ConnectionInterface $httpConnection, $requestId): HttpConnection;
 

--- a/app/Http/Controllers/ControlMessageController.php
+++ b/app/Http/Controllers/ControlMessageController.php
@@ -190,7 +190,7 @@ class ControlMessageController implements MessageComponentInterface
 
                 $connectionInfo = $this->connectionManager->storeConnection($data->host, $data->subdomain, $data->server_host, $connection);
 
-                $this->connectionManager->limitConnectionLength($connectionInfo, config('expose-server.maximum_connection_length'));
+                $this->connectionManager->limitConnectionLength($connectionInfo, config('expose-server.maximum_connection_length'), $user);
 
                 return $this->resolveConnectionMessage($connectionInfo, $user);
             })

--- a/tests/Feature/Server/ConnectionManagerTest.php
+++ b/tests/Feature/Server/ConnectionManagerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature\Server;
+
+use Expose\Server\Connections\ConnectionManager;
+use Expose\Server\Connections\ControlConnection;
+use Expose\Server\Contracts\LoggerRepository;
+use Expose\Server\Contracts\StatisticsCollector;
+use Expose\Server\Contracts\SubdomainGenerator;
+use Expose\Server\Contracts\UserRepository;
+use Mockery;
+use React\EventLoop\LoopInterface;
+use Tests\Feature\TestCase;
+
+class ConnectionManagerTest extends TestCase
+{
+    /** @test */
+    public function it_does_not_apply_connection_length_limits_to_users_that_can_specify_subdomains()
+    {
+        $loop = Mockery::mock(LoopInterface::class);
+        $loop->shouldNotReceive('addTimer');
+
+        $statisticsCollector = Mockery::mock(StatisticsCollector::class);
+        $statisticsCollector->shouldNotReceive('cooldownTriggered');
+
+        $connection = Mockery::mock(ControlConnection::class);
+        $connection->authToken = 'pro-user-token';
+        $connection->shouldNotReceive('setMaximumConnectionLength');
+        $connection->shouldNotReceive('closeWithoutReconnect');
+
+        $this->app->instance(UserRepository::class, Mockery::mock(UserRepository::class));
+
+        $manager = new ConnectionManager(
+            Mockery::mock(SubdomainGenerator::class),
+            $statisticsCollector,
+            Mockery::mock(LoggerRepository::class),
+            $loop
+        );
+
+        $manager->limitConnectionLength($connection, 60, [
+            'can_specify_subdomains' => 1,
+        ]);
+    }
+
+    /** @test */
+    public function it_still_applies_connection_length_limits_to_users_without_custom_subdomains()
+    {
+        config()->set('expose-server.connection_cooldown_period', 10);
+
+        $timerCallback = null;
+
+        $loop = Mockery::mock(LoopInterface::class);
+        $loop->shouldReceive('addTimer')
+            ->once()
+            ->withArgs(function ($seconds, $callback) use (&$timerCallback) {
+                $this->assertSame(60, $seconds);
+                $timerCallback = $callback;
+
+                return is_callable($callback);
+            });
+
+        $statisticsCollector = Mockery::mock(StatisticsCollector::class);
+        $statisticsCollector->shouldReceive('cooldownTriggered')->once();
+
+        $connection = Mockery::mock(ControlConnection::class);
+        $connection->authToken = 'regular-user-token';
+        $connection->shouldReceive('setMaximumConnectionLength')->once()->with(1);
+        $connection->shouldReceive('closeWithoutReconnect')->once();
+
+        $userRepository = Mockery::mock(UserRepository::class);
+        $userRepository->shouldReceive('setCooldownForToken')
+            ->once()
+            ->withArgs(function ($authToken, $cooldownEndsAt) {
+                $this->assertSame('regular-user-token', $authToken);
+                $this->assertIsInt($cooldownEndsAt);
+                $this->assertGreaterThan(time(), $cooldownEndsAt);
+
+                return true;
+            })
+            ->andReturn(\React\Promise\resolve(null));
+
+        $this->app->instance(UserRepository::class, $userRepository);
+
+        $manager = new ConnectionManager(
+            Mockery::mock(SubdomainGenerator::class),
+            $statisticsCollector,
+            Mockery::mock(LoggerRepository::class),
+            $loop
+        );
+
+        $manager->limitConnectionLength($connection, 1, [
+            'can_specify_subdomains' => 0,
+        ]);
+
+        $this->assertNotNull($timerCallback);
+
+        $timerCallback();
+    }
+}


### PR DESCRIPTION
## Summary
- exempt authenticated users with `can_specify_subdomains = 1` from `maximum_connection_length`
- keep the existing timeout and cooldown flow for non-Pro users
- add regression tests covering both the exempt and non-exempt paths

## Why
Free servers should not disconnect Pro users just because a server-wide connection time limit is configured. This keeps the free-server limit in place for non-Pro users while allowing Pro users to stay connected without interruption.

## Validation
- `vendor/bin/phpunit tests/Feature/Server/ConnectionManagerTest.php`
- `vendor/bin/phpunit tests/Feature/Server/TunnelTest.php`