### PR TITLE
Validate on-demand TLS against active tunnels

### DIFF
--- a/app/Factory.php
+++ b/app/Factory.php
@@ -33,6 +33,7 @@ use Expose\Server\Http\Controllers\Admin\StoreSettingsController;
 use Expose\Server\Http\Controllers\Admin\StoreSubdomainController;
 use Expose\Server\Http\Controllers\Admin\StoreUsersController;
 use Expose\Server\Http\Controllers\Admin\UpdateDomainController;
+use Expose\Server\Http\Controllers\CanIssueCertificateController;
 use Expose\Server\Http\Controllers\ControlMessageController;
 use Expose\Server\Http\Controllers\HealthController;
 use Expose\Server\Http\Controllers\TunnelMessageController;
@@ -137,6 +138,17 @@ class Factory
         return $wsServer;
     }
 
+    protected function addCertificateAuthorizationRoute()
+    {
+        // Caddy's on-demand TLS asks this endpoint before issuing a certificate.
+        // Gated to the loopback interface so it can only be reached by the local
+        // Caddy process - this keeps it from shadowing a tunnelled app's path and
+        // from leaking which tunnels are live to external callers.
+        $loopbackCondition = 'request.headers.get("Host") in ["127.0.0.1", "127.0.0.1:'.$this->port.'"]';
+
+        $this->router->get('/expose/can-issue-certificate', CanIssueCertificateController::class, $loopbackCondition);
+    }
+
     protected function addAdminRoutes()
     {
         $adminCondition = 'request.headers.get("Host") matches "/^'.config('expose-server.subdomain').'\\\\./i"';
@@ -218,6 +230,8 @@ class Factory
             ->addAdminRoutes();
 
         $controlConnection = $this->addControlConnectionRoute();
+
+        $this->addCertificateAuthorizationRoute();
 
         $this->addTunnelRoute();
 

--- a/app/Http/Controllers/CanIssueCertificateController.php
+++ b/app/Http/Controllers/CanIssueCertificateController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Expose\Server\Http\Controllers;
+
+use Expose\Common\Http\Controllers\Controller;
+use Expose\Server\Contracts\ConnectionManager;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Ratchet\ConnectionInterface;
+
+class CanIssueCertificateController extends Controller
+{
+    public function handle(Request $request, ConnectionInterface $httpConnection)
+    {
+        $domain = $request->get('domain');
+
+        if (blank($domain)) {
+            $httpConnection->send(respond_html('Missing domain', 400));
+
+            return;
+        }
+
+        // Parse the host the same way TunnelMessageController routes a request,
+        // so the certificate decision matches whether a request for this host
+        // would actually be served by a live tunnel.
+        $serverHost = Str::before(Str::after($domain, '.'), ':');
+        $subdomain = Str::before($domain, '.'.$serverHost);
+
+        /** @var ConnectionManager $connectionManager */
+        $connectionManager = app(ConnectionManager::class);
+
+        $hasActiveTunnel = $subdomain !== $domain
+            && $connectionManager->findControlConnectionForSubdomainAndServerHost($subdomain, $serverHost) !== null;
+
+        // Caddy on-demand TLS treats any 2xx as "issue", anything else as "refuse".
+        $httpConnection->send(respond_html(
+            $hasActiveTunnel ? 'OK' : 'No active tunnel',
+            $hasActiveTunnel ? 200 : 404
+        ));
+    }
+}

--- a/tests/Feature/Server/TunnelTest.php
+++ b/tests/Feature/Server/TunnelTest.php
@@ -182,6 +182,34 @@ class TunnelTest extends TestCase
     }
 
     /** @test */
+    public function it_refuses_certificate_issuance_for_a_host_without_an_active_tunnel()
+    {
+        $this->expectException(ResponseException::class);
+        $this->expectExceptionMessage(404);
+
+        $this->await($this->browser->get('http://127.0.0.1:8080/expose/can-issue-certificate?domain=tunnel.localhost', [
+            'Host' => '127.0.0.1:8080',
+        ]));
+    }
+
+    /** @test */
+    public function it_allows_certificate_issuance_for_a_host_with_an_active_tunnel()
+    {
+        $this->app['config']['expose-server.validate_auth_tokens'] = false;
+
+        $this->createTestHttpServer();
+
+        $client = $this->createClient();
+        $this->await($client->connectToServer('127.0.0.1:8085', 'tunnel'));
+
+        $response = $this->await($this->browser->get('http://127.0.0.1:8080/expose/can-issue-certificate?domain=tunnel.localhost', [
+            'Host' => '127.0.0.1:8080',
+        ]));
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    /** @test */
     public function it_sends_incoming_requests_to_the_connected_client()
     {
         $this->app['config']['expose-server.validate_auth_tokens'] = false;


### PR DESCRIPTION
## Why

Caddy's on-demand TLS `ask` currently points at the platform (`https://expose.dev/api/tunnel`), which approves **any subdomain of a registered custom domain**. On eu-1 that has produced **259 registered domains → ~16,954 stored certs (~65× fan-out)** — bot/crawler/`www`-variant subdomains each mint a permanent cert. That huge pool is what Caddy loads + parses (`crypto/x509.parseCertificate` + `encoding/pem.Decode` dominate the heap) under handshake floods, spiking memory ~1 GB and pinning CPU — which on smaller boxes (us-1: 1 vCPU / 1 GB) trips the health-check timeout/restart loop.

## What

A local endpoint `GET /expose/can-issue-certificate?domain=<host>` on the expose server that Caddy can ask before issuing:

- **200** if a live tunnel exists for the host — using `findControlConnectionForSubdomainAndServerHost`, the *same* lookup request routing uses.
- **404** otherwise.

Gated to the **loopback interface** (`Host` ∈ `127.0.0.1[:port]`) so it can only be reached by the local Caddy process — it can't shadow a tunnelled app's path or leak which tunnels are live to external callers. Registered before the catch-all tunnel route.

## Tests

- `it_refuses_certificate_issuance_for_a_host_without_an_active_tunnel` → 404
- `it_allows_certificate_issuance_for_a_host_with_an_active_tunnel` → 200

Full `tests/Feature/Server` suite passes (48 tests).
