### PR TITLE
Allow on-demand certs for the server's own infrastructure hosts

### DIFF
--- a/app/Http/Controllers/CanIssueCertificateController.php
+++ b/app/Http/Controllers/CanIssueCertificateController.php
@@ -3,11 +3,17 @@
 namespace Expose\Server\Http\Controllers;
 
 use Expose\Common\Http\Controllers\Controller;
+use Expose\Server\Configuration;
 use Expose\Server\Contracts\ConnectionManager;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Ratchet\ConnectionInterface;
 
+/**
+ * Answers Caddy's on-demand TLS "ask" endpoint, permitting certificate
+ * issuance only for the server's infrastructure hosts or a host with a live
+ * tunnel. See the SSL documentation for how to wire up the Caddyfile.
+ */
 class CanIssueCertificateController extends Controller
 {
     public function handle(Request $request, ConnectionInterface $httpConnection)
@@ -20,22 +26,45 @@ class CanIssueCertificateController extends Controller
             return;
         }
 
-        // Parse the host the same way TunnelMessageController routes a request,
-        // so the certificate decision matches whether a request for this host
-        // would actually be served by a live tunnel.
-        $serverHost = Str::before(Str::after($domain, '.'), ':');
-        $subdomain = Str::before($domain, '.'.$serverHost);
-
-        /** @var ConnectionManager $connectionManager */
-        $connectionManager = app(ConnectionManager::class);
-
-        $hasActiveTunnel = $subdomain !== $domain
-            && $connectionManager->findControlConnectionForSubdomainAndServerHost($subdomain, $serverHost) !== null;
+        $allowed = $this->isInfrastructureHost($domain) || $this->hasActiveTunnel($domain);
 
         // Caddy on-demand TLS treats any 2xx as "issue", anything else as "refuse".
         $httpConnection->send(respond_html(
-            $hasActiveTunnel ? 'OK' : 'No active tunnel',
-            $hasActiveTunnel ? 200 : 404
+            $allowed ? 'OK' : 'No active tunnel',
+            $allowed ? 200 : 404
         ));
+    }
+
+    /**
+     * Hosts that may obtain a certificate without a live tunnel: the bare
+     * server hostname (the wildcard certificate covers *.host but not the host
+     * itself, so it reaches the on-demand path), the admin dashboard subdomain,
+     * and any host configured under on_demand_tls.always_allow_hosts.
+     */
+    protected function isInfrastructureHost(string $domain): bool
+    {
+        $hostname = app(Configuration::class)->hostname();
+
+        return $domain === $hostname
+            || $domain === config('expose-server.subdomain').'.'.$hostname
+            || in_array($domain, config('expose-server.on_demand_tls.always_allow_hosts', []), true);
+    }
+
+    /**
+     * Whether a control connection for this host is currently registered. The
+     * host is parsed exactly like TunnelMessageController routes a request, so
+     * the certificate decision matches whether the request would be served.
+     */
+    protected function hasActiveTunnel(string $domain): bool
+    {
+        $serverHost = Str::before(Str::after($domain, '.'), ':');
+        $subdomain = Str::before($domain, '.'.$serverHost);
+
+        if ($subdomain === $domain) {
+            return false;
+        }
+
+        return app(ConnectionManager::class)
+            ->findControlConnectionForSubdomainAndServerHost($subdomain, $serverHost) !== null;
     }
 }

--- a/config/expose-server.php
+++ b/config/expose-server.php
@@ -106,6 +106,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | On-Demand TLS
+    |--------------------------------------------------------------------------
+    |
+    | When you terminate TLS with Caddy's on-demand TLS, point its "ask"
+    | endpoint at /expose/can-issue-certificate. The server then only permits
+    | certificate issuance for its own host, the admin subdomain, or a host
+    | that currently has a live tunnel. List any additional non-tunnel hosts
+    | that should always be allowed to obtain a certificate below.
+    |
+    */
+    'on_demand_tls' => [
+        'always_allow_hosts' => [],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Subdomain Generator
     |--------------------------------------------------------------------------
     |

--- a/tests/Feature/Server/TunnelTest.php
+++ b/tests/Feature/Server/TunnelTest.php
@@ -210,6 +210,40 @@ class TunnelTest extends TestCase
     }
 
     /** @test */
+    public function it_allows_certificate_issuance_for_the_server_host()
+    {
+        // The bare server hostname is not tunnel-backed (the wildcard cert
+        // covers *.host but not the host itself) and must always be allowed.
+        $response = $this->await($this->browser->get('http://127.0.0.1:8080/expose/can-issue-certificate?domain=localhost', [
+            'Host' => '127.0.0.1:8080',
+        ]));
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    /** @test */
+    public function it_allows_certificate_issuance_for_the_admin_subdomain()
+    {
+        $response = $this->await($this->browser->get('http://127.0.0.1:8080/expose/can-issue-certificate?domain=expose.localhost', [
+            'Host' => '127.0.0.1:8080',
+        ]));
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    /** @test */
+    public function it_allows_certificate_issuance_for_configured_always_allow_hosts()
+    {
+        $this->app['config']['expose-server.on_demand_tls.always_allow_hosts'] = ['status.example.com'];
+
+        $response = $this->await($this->browser->get('http://127.0.0.1:8080/expose/can-issue-certificate?domain=status.example.com', [
+            'Host' => '127.0.0.1:8080',
+        ]));
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    /** @test */
     public function it_sends_incoming_requests_to_the_connected_client()
     {
         $this->app['config']['expose-server.validate_auth_tokens'] = false;


### PR DESCRIPTION
## Why

Follow-up to the on-demand TLS `ask` endpoint (`/expose/can-issue-certificate`, added in #14). On a canary deploy it refused the **bare server hostname** (`ap-1.sharedwithexpose.com`) and the admin subdomain, because neither is backed by a tunnel — but the wildcard certificate covers `*.host`, **not** the host itself, so the server host reaches the on-demand path. The refusal failed the control-connection TLS handshake (`ECONNRESET`), so clients could no longer connect.

## What

- **Always allow infrastructure hosts** — the server's own hostname and the admin subdomain — mirroring the allows the previous platform `ask` had. This fixes the canary regression.
- **Configurable allow-list** — a new optional `on_demand_tls.always_allow_hosts` config for any additional non-tunnel hosts that should still obtain a certificate (e.g. a status page). Default empty.
- Otherwise unchanged: a certificate is permitted only for a host with a **live tunnel**.
- Trims the controller doc-comment (the full explanation goes into the SSL docs, handled separately).

```php
// config/expose-server.php
'on_demand_tls' => [
    'always_allow_hosts' => [],
],
```

## Safety

The endpoint stays **inert until a Caddyfile points its on-demand `ask` at it**, so merging changes nothing for existing setups. No expose-config switch is required to use the feature; activation lives entirely in Caddy.

## Tests

`tests/Feature/Server` (56 passing), incl. certificate cases: refuse-without-tunnel, allow-with-tunnel, allow-server-host, allow-admin-subdomain, allow-configured-host.
